### PR TITLE
Feature/empty fields rule check

### DIFF
--- a/src/libs/response-rules-interpreter.ts
+++ b/src/libs/response-rules-interpreter.ts
@@ -14,8 +14,7 @@ import { ParsedQs } from 'qs';
  */
 export class ResponseRulesInterpreter {
   private targets: {
-    [key in
-      | Exclude<ResponseRuleTargets, 'header' | 'request_number'>
+    [key in | Exclude<ResponseRuleTargets, 'header' | 'request_number'>
       | 'bodyRaw']: any;
   };
 
@@ -43,8 +42,8 @@ export class ResponseRulesInterpreter {
 
     if (this.sequentialResponse) {
       return this.routeResponses[
-        (requestNumber - 1) % this.routeResponses.length
-      ];
+      (requestNumber - 1) % this.routeResponses.length
+        ];
     } else {
       let response = this.routeResponses.find((routeResponse) => {
         if (routeResponse.rules.length === 0) {
@@ -53,11 +52,11 @@ export class ResponseRulesInterpreter {
 
         return routeResponse.rulesOperator === 'AND'
           ? routeResponse.rules.every((rule) =>
-              this.isValidRule(rule, requestNumber)
-            )
+            this.isValidRule(rule, requestNumber)
+          )
           : routeResponse.rules.some((rule) =>
-              this.isValidRule(rule, requestNumber)
-            );
+            this.isValidRule(rule, requestNumber)
+          );
       });
 
       if (response === undefined) {
@@ -95,13 +94,12 @@ export class ResponseRulesInterpreter {
       }
     }
 
-    if (rule.isEmpty && rule.modifier) {
-      if(value === null || value === undefined ) {
-        return true;
-      }
-      if(rule.value && rule.value.toLowerCase() === 'array') {
+    if (rule.operator === 'null' && rule.modifier) {
+      return (value === null || value === undefined);
+    }
+
+    if (rule.operator === 'empty_array' && rule.modifier) {
         return Array.isArray(value) && value.length < 1;
-      }
     }
 
     if (value === undefined) {
@@ -121,8 +119,7 @@ export class ResponseRulesInterpreter {
     let regex: RegExp;
 
 
-
-    if (rule.isRegex) {
+    if (rule.operator === 'regex') {
       regex = new RegExp(rule.value);
 
       return Array.isArray(value)

--- a/src/libs/response-rules-interpreter.ts
+++ b/src/libs/response-rules-interpreter.ts
@@ -95,6 +95,15 @@ export class ResponseRulesInterpreter {
       }
     }
 
+    if (rule.isEmpty && rule.modifier) {
+      if(value === null || value === undefined ) {
+        return true;
+      }
+      if(rule.value && rule.value.toLowerCase() === 'array') {
+        return Array.isArray(value) && value.length < 1;
+      }
+    }
+
     if (value === undefined) {
       return false;
     }
@@ -110,6 +119,9 @@ export class ResponseRulesInterpreter {
     }
 
     let regex: RegExp;
+
+
+
     if (rule.isRegex) {
       regex = new RegExp(rule.value);
 

--- a/test/response-rules/response-rules-interpreter.spec.ts
+++ b/test/response-rules/response-rules-interpreter.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { Request } from 'express';
 import QueryString from 'qs';
 import { xml2js } from 'xml-js';
-import { ResponseRulesInterpreter } from '../src/libs/response-rules-interpreter';
+import { ResponseRulesInterpreter } from '../../src/libs/response-rules-interpreter';
 
 const routeResponse403: RouteResponse = {
   uuid: '',
@@ -88,7 +88,8 @@ describe('Response rules interpreter', () => {
               target: '' as ResponseRuleTargets,
               modifier: 'prop',
               value: 'value',
-              isRegex: false
+              isRegex: false,
+              isEmpty: false
             }
           ],
           body: 'invalid'
@@ -124,7 +125,8 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: 'obj.prop',
                 value: '^value',
-                isRegex: true
+                isRegex: true,
+                isEmpty: false
               }
             ],
             body: 'query1'
@@ -159,7 +161,8 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: 'obj.prop',
                 value: 'val',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'query2'
@@ -194,7 +197,8 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: 'obj.prop',
                 value: 'value',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'query3'
@@ -229,7 +233,8 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: 'array',
                 value: 'test1|test2',
-                isRegex: true
+                isRegex: true,
+                isEmpty: false
               }
             ],
             body: 'query4'
@@ -264,7 +269,8 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: 'array',
                 value: 'test2',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'query5'
@@ -299,7 +305,8 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: '',
                 value: 'value',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'query6'
@@ -334,7 +341,8 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: 'prop',
                 value: 'value',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'query7'
@@ -346,6 +354,42 @@ describe('Response rules interpreter', () => {
       ).chooseResponse(1);
 
       expect(routeResponse.body).to.be.equal('unauthorized');
+    });
+
+    it('should return response if isEmpty is checked and no value query param was given', () => {
+      const request: Request = {
+        header: function (headerName: string) {
+          const headers = { 'Content-Type': 'application/json' };
+
+          return headers[headerName];
+        },
+        body: '',
+        query: { prop: undefined } as QueryString.ParsedQs
+      } as Request;
+
+      const routeResponse = new ResponseRulesInterpreter(
+        [
+          routeResponse403,
+          {
+            ...routeResponseTemplate,
+            rules: [
+              {
+                target: 'query',
+                modifier: 'shouldNotBeSet',
+                value: '',
+                isRegex: false,
+                isEmpty: true
+              }
+            ],
+            body: 'query7'
+          }
+        ],
+        request,
+        false,
+        false
+      ).chooseResponse(1);
+
+      expect(routeResponse.body).to.be.equal('query7');
     });
   });
 
@@ -371,7 +415,8 @@ describe('Response rules interpreter', () => {
                 target: 'params',
                 modifier: 'id',
                 value: '^1',
-                isRegex: true
+                isRegex: true,
+                isEmpty: false
               }
             ],
             body: 'params1'
@@ -405,7 +450,8 @@ describe('Response rules interpreter', () => {
                 target: 'params',
                 modifier: 'id',
                 value: '111',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'params2'
@@ -439,7 +485,8 @@ describe('Response rules interpreter', () => {
                 target: 'params',
                 modifier: '',
                 value: '111',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'params3'
@@ -473,7 +520,8 @@ describe('Response rules interpreter', () => {
                 target: 'params',
                 modifier: '',
                 value: '11',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'params4'
@@ -507,7 +555,8 @@ describe('Response rules interpreter', () => {
                 target: 'params',
                 modifier: '',
                 value: '11',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'params5'
@@ -545,7 +594,8 @@ describe('Response rules interpreter', () => {
                 target: 'request_number',
                 modifier: '',
                 value: '1',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'request_number_1'
@@ -558,7 +608,7 @@ describe('Response rules interpreter', () => {
       expect(routeResponse.body).to.be.equal('request_number_1');
     });
 
-    it("should not return response if request number don't matches", () => {
+    it('should not return response if request number don\'t matches', () => {
       const request: Request = {
         header: function (headerName: string) {
           const headers = {
@@ -581,7 +631,8 @@ describe('Response rules interpreter', () => {
                 target: 'request_number',
                 modifier: '',
                 value: '1',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'request_number_1'
@@ -617,7 +668,8 @@ describe('Response rules interpreter', () => {
                 target: 'request_number',
                 modifier: '',
                 value: '^[1-9][0-9]?$|^100$',
-                isRegex: true
+                isRegex: true,
+                isEmpty: false
               }
             ],
             body: 'request_number_regex'
@@ -630,7 +682,7 @@ describe('Response rules interpreter', () => {
       expect(routeResponse.body).to.be.equal('request_number_regex');
     });
 
-    it("should not return response if request don't matches regex", () => {
+    it('should not return response if request don\'t matches regex', () => {
       const request: Request = {
         header: function (headerName: string) {
           const headers = {
@@ -653,7 +705,8 @@ describe('Response rules interpreter', () => {
                 target: 'request_number',
                 modifier: '',
                 value: '^[1-9][0-9]?$|^100$',
-                isRegex: true
+                isRegex: true,
+                isEmpty: false
               }
             ],
             body: 'request_number_regex'
@@ -689,13 +742,15 @@ describe('Response rules interpreter', () => {
                 target: 'header',
                 modifier: 'Authorization',
                 value: '^$|s+',
-                isRegex: true
+                isRegex: true,
+                isEmpty: false
               },
               {
                 target: 'request_number',
                 modifier: '',
                 value: '1|2',
-                isRegex: true
+                isRegex: true,
+                isEmpty: false
               }
             ],
             rulesOperator: 'AND',
@@ -798,7 +853,8 @@ describe('Response rules interpreter', () => {
                 target: 'header',
                 modifier: 'Accept-Charset',
                 value: '^UTF',
-                isRegex: true
+                isRegex: true,
+                isEmpty: false
               }
             ],
             body: 'header1'
@@ -834,7 +890,8 @@ describe('Response rules interpreter', () => {
                 target: 'header',
                 modifier: 'Accept-Charset',
                 value: 'UTF-8',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'header2'
@@ -870,7 +927,8 @@ describe('Response rules interpreter', () => {
                 target: 'header',
                 modifier: 'Accept-Charset',
                 value: 'UTF-16',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'header3'
@@ -906,7 +964,8 @@ describe('Response rules interpreter', () => {
                 target: 'header',
                 modifier: 'Accept-Charset',
                 value: 'UTF-16',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'header4'
@@ -942,7 +1001,8 @@ describe('Response rules interpreter', () => {
                 target: 'header',
                 modifier: '',
                 value: 'UTF-8',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'header5'
@@ -982,7 +1042,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: '',
                 value: 'value',
-                isRegex: true
+                isRegex: true,
+                isEmpty: false
               }
             ],
             body: 'body1'
@@ -1017,7 +1078,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: '',
                 value: 'bodyvalue',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'body2'
@@ -1052,7 +1114,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: '',
                 value: 'body',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'body3'
@@ -1088,7 +1151,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'name',
                 value: 'john',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'body4'
@@ -1124,7 +1188,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'user.0.name',
                 value: 'John',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'body5'
@@ -1160,7 +1225,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'user.0.name',
                 value: '^John',
-                isRegex: true
+                isRegex: true,
+                isEmpty: false
               }
             ],
             body: 'body6'
@@ -1196,7 +1262,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'users',
                 value: 'John',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'body7'
@@ -1232,7 +1299,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'users',
                 value: '^John',
-                isRegex: true
+                isRegex: true,
+                isEmpty: false
               }
             ],
             body: 'body8'
@@ -1268,7 +1336,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'test',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'body9'
@@ -1304,7 +1373,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: '1',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'body10'
@@ -1340,7 +1410,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'false',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'body11'
@@ -1376,7 +1447,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'param1',
                 value: 'value1',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'body12'
@@ -1412,7 +1484,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'param1',
                 value: '^value',
-                isRegex: true
+                isRegex: true,
+                isEmpty: false
               }
             ],
             body: 'body13'
@@ -1448,7 +1521,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'params',
                 value: 'value2',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'body14'
@@ -1484,7 +1558,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'params.prop2',
                 value: 'value2',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'body15'
@@ -1519,7 +1594,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: '',
                 value: 'bodyvalue',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'body16'
@@ -1554,7 +1630,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: '',
                 value: 'value',
-                isRegex: true
+                isRegex: true,
+                isEmpty: false
               }
             ],
             body: 'body17'
@@ -1590,7 +1667,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'prop1',
                 value: '',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             body: 'body19'
@@ -1626,7 +1704,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'prop1',
                 value: null,
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               } as any
             ],
             body: 'body19'
@@ -1663,7 +1742,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'user.name._text',
                 value: 'John',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               } as any
             ],
             body: 'body20'
@@ -1700,7 +1780,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'user._attributes.userId',
                 value: '1',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               } as any
             ],
             body: 'body21'
@@ -1737,7 +1818,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: '_declaration._attributes.version',
                 value: '1.0',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               } as any
             ],
             body: 'body21'
@@ -1775,13 +1857,15 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'bodyvalue',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               },
               {
                 target: 'header',
                 modifier: 'Test-Header',
                 value: 'headervalue',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             rulesOperator: 'AND',
@@ -1818,13 +1902,15 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'bodyvalue',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               },
               {
                 target: 'header',
                 modifier: 'Test-Header',
                 value: 'headervalue1',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             rulesOperator: 'AND',
@@ -1862,13 +1948,15 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'bodyvalue',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               },
               {
                 target: 'header',
                 modifier: 'Test-Header',
                 value: 'headervalue',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             rulesOperator: 'OR',
@@ -1905,13 +1993,15 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'bodyvalue',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               },
               {
                 target: 'header',
                 modifier: 'Test-Header',
                 value: 'headervalue',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             rulesOperator: 'OR',
@@ -1959,7 +2049,8 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'bodyvalue',
-                isRegex: false
+                isRegex: false,
+                isEmpty: false
               }
             ],
             rulesOperator: 'OR',

--- a/test/response-rules/response-rules-interpreter.spec.ts
+++ b/test/response-rules/response-rules-interpreter.spec.ts
@@ -88,8 +88,7 @@ describe('Response rules interpreter', () => {
               target: '' as ResponseRuleTargets,
               modifier: 'prop',
               value: 'value',
-              isRegex: false,
-              isEmpty: false
+              operator: 'equals'
             }
           ],
           body: 'invalid'
@@ -125,8 +124,7 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: 'obj.prop',
                 value: '^value',
-                isRegex: true,
-                isEmpty: false
+                operator: 'regex'
               }
             ],
             body: 'query1'
@@ -161,8 +159,7 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: 'obj.prop',
                 value: 'val',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'query2'
@@ -197,8 +194,7 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: 'obj.prop',
                 value: 'value',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'query3'
@@ -233,8 +229,7 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: 'array',
                 value: 'test1|test2',
-                isRegex: true,
-                isEmpty: false
+                operator: 'regex'
               }
             ],
             body: 'query4'
@@ -269,8 +264,7 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: 'array',
                 value: 'test2',
-                isRegex: false,
-                isEmpty: false
+                operator: 'regex'
               }
             ],
             body: 'query5'
@@ -305,8 +299,7 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: '',
                 value: 'value',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'query6'
@@ -341,8 +334,7 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: 'prop',
                 value: 'value',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'query7'
@@ -356,7 +348,7 @@ describe('Response rules interpreter', () => {
       expect(routeResponse.body).to.be.equal('unauthorized');
     });
 
-    it('should return response if isEmpty is checked and no value query param was given', () => {
+    it('should return response if operator is "null" and no value query param was given', () => {
       const request: Request = {
         header: function (headerName: string) {
           const headers = { 'Content-Type': 'application/json' };
@@ -377,8 +369,42 @@ describe('Response rules interpreter', () => {
                 target: 'query',
                 modifier: 'shouldNotBeSet',
                 value: '',
-                isRegex: false,
-                isEmpty: true
+                operator: 'null'
+              }
+            ],
+            body: 'query7'
+          }
+        ],
+        request,
+        false,
+        false
+      ).chooseResponse(1);
+
+      expect(routeResponse.body).to.be.equal('query7');
+    });
+
+    it('should return response if operator is "empty_array" and empty array was given', () => {
+      const request: Request = {
+        header: function (headerName: string) {
+          const headers = { 'Content-Type': 'application/json' };
+
+          return headers[headerName];
+        },
+        body: '',
+        query: { prop: undefined, examples: []} as QueryString.ParsedQs
+      } as Request;
+
+      const routeResponse = new ResponseRulesInterpreter(
+        [
+          routeResponse403,
+          {
+            ...routeResponseTemplate,
+            rules: [
+              {
+                target: 'query',
+                modifier: 'examples',
+                value: '',
+                operator: 'empty_array'
               }
             ],
             body: 'query7'
@@ -415,8 +441,7 @@ describe('Response rules interpreter', () => {
                 target: 'params',
                 modifier: 'id',
                 value: '^1',
-                isRegex: true,
-                isEmpty: false
+                operator: 'regex'
               }
             ],
             body: 'params1'
@@ -450,8 +475,7 @@ describe('Response rules interpreter', () => {
                 target: 'params',
                 modifier: 'id',
                 value: '111',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'params2'
@@ -485,8 +509,7 @@ describe('Response rules interpreter', () => {
                 target: 'params',
                 modifier: '',
                 value: '111',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'params3'
@@ -520,8 +543,7 @@ describe('Response rules interpreter', () => {
                 target: 'params',
                 modifier: '',
                 value: '11',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'params4'
@@ -555,8 +577,7 @@ describe('Response rules interpreter', () => {
                 target: 'params',
                 modifier: '',
                 value: '11',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'params5'
@@ -594,8 +615,7 @@ describe('Response rules interpreter', () => {
                 target: 'request_number',
                 modifier: '',
                 value: '1',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'request_number_1'
@@ -631,8 +651,7 @@ describe('Response rules interpreter', () => {
                 target: 'request_number',
                 modifier: '',
                 value: '1',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'request_number_1'
@@ -668,8 +687,7 @@ describe('Response rules interpreter', () => {
                 target: 'request_number',
                 modifier: '',
                 value: '^[1-9][0-9]?$|^100$',
-                isRegex: true,
-                isEmpty: false
+                operator: 'regex'
               }
             ],
             body: 'request_number_regex'
@@ -705,8 +723,7 @@ describe('Response rules interpreter', () => {
                 target: 'request_number',
                 modifier: '',
                 value: '^[1-9][0-9]?$|^100$',
-                isRegex: true,
-                isEmpty: false
+                operator: 'regex'
               }
             ],
             body: 'request_number_regex'
@@ -742,15 +759,13 @@ describe('Response rules interpreter', () => {
                 target: 'header',
                 modifier: 'Authorization',
                 value: '^$|s+',
-                isRegex: true,
-                isEmpty: false
+                operator: 'regex'
               },
               {
                 target: 'request_number',
                 modifier: '',
                 value: '1|2',
-                isRegex: true,
-                isEmpty: false
+                operator: 'regex'
               }
             ],
             rulesOperator: 'AND',
@@ -853,8 +868,7 @@ describe('Response rules interpreter', () => {
                 target: 'header',
                 modifier: 'Accept-Charset',
                 value: '^UTF',
-                isRegex: true,
-                isEmpty: false
+                operator: 'regex'
               }
             ],
             body: 'header1'
@@ -890,8 +904,7 @@ describe('Response rules interpreter', () => {
                 target: 'header',
                 modifier: 'Accept-Charset',
                 value: 'UTF-8',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'header2'
@@ -927,8 +940,7 @@ describe('Response rules interpreter', () => {
                 target: 'header',
                 modifier: 'Accept-Charset',
                 value: 'UTF-16',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'header3'
@@ -964,8 +976,7 @@ describe('Response rules interpreter', () => {
                 target: 'header',
                 modifier: 'Accept-Charset',
                 value: 'UTF-16',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'header4'
@@ -1001,8 +1012,7 @@ describe('Response rules interpreter', () => {
                 target: 'header',
                 modifier: '',
                 value: 'UTF-8',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'header5'
@@ -1042,8 +1052,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: '',
                 value: 'value',
-                isRegex: true,
-                isEmpty: false
+                operator: 'regex'
               }
             ],
             body: 'body1'
@@ -1078,8 +1087,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: '',
                 value: 'bodyvalue',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'body2'
@@ -1114,8 +1122,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: '',
                 value: 'body',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'body3'
@@ -1151,8 +1158,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'name',
                 value: 'john',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'body4'
@@ -1188,8 +1194,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'user.0.name',
                 value: 'John',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'body5'
@@ -1225,8 +1230,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'user.0.name',
                 value: '^John',
-                isRegex: true,
-                isEmpty: false
+                operator: 'regex'
               }
             ],
             body: 'body6'
@@ -1262,8 +1266,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'users',
                 value: 'John',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'body7'
@@ -1299,8 +1302,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'users',
                 value: '^John',
-                isRegex: true,
-                isEmpty: false
+                operator: 'regex'
               }
             ],
             body: 'body8'
@@ -1336,8 +1338,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'test',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'body9'
@@ -1373,8 +1374,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: '1',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'body10'
@@ -1410,8 +1410,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'false',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'body11'
@@ -1447,8 +1446,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'param1',
                 value: 'value1',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'body12'
@@ -1484,8 +1482,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'param1',
                 value: '^value',
-                isRegex: true,
-                isEmpty: false
+                operator: 'regex'
               }
             ],
             body: 'body13'
@@ -1521,8 +1518,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'params',
                 value: 'value2',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'body14'
@@ -1558,8 +1554,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'params.prop2',
                 value: 'value2',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'body15'
@@ -1594,8 +1589,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: '',
                 value: 'bodyvalue',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'body16'
@@ -1630,8 +1624,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: '',
                 value: 'value',
-                isRegex: true,
-                isEmpty: false
+                operator: 'regex'
               }
             ],
             body: 'body17'
@@ -1667,8 +1660,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'prop1',
                 value: '',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             body: 'body19'
@@ -1704,8 +1696,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'prop1',
                 value: null,
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               } as any
             ],
             body: 'body19'
@@ -1742,8 +1733,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'user.name._text',
                 value: 'John',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               } as any
             ],
             body: 'body20'
@@ -1780,8 +1770,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'user._attributes.userId',
                 value: '1',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               } as any
             ],
             body: 'body21'
@@ -1818,8 +1807,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: '_declaration._attributes.version',
                 value: '1.0',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               } as any
             ],
             body: 'body21'
@@ -1857,15 +1845,13 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'bodyvalue',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               },
               {
                 target: 'header',
                 modifier: 'Test-Header',
                 value: 'headervalue',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             rulesOperator: 'AND',
@@ -1902,15 +1888,13 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'bodyvalue',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               },
               {
                 target: 'header',
                 modifier: 'Test-Header',
                 value: 'headervalue1',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             rulesOperator: 'AND',
@@ -1948,15 +1932,13 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'bodyvalue',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               },
               {
                 target: 'header',
                 modifier: 'Test-Header',
                 value: 'headervalue',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             rulesOperator: 'OR',
@@ -1993,15 +1975,13 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'bodyvalue',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               },
               {
                 target: 'header',
                 modifier: 'Test-Header',
                 value: 'headervalue',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             rulesOperator: 'OR',
@@ -2049,8 +2029,7 @@ describe('Response rules interpreter', () => {
                 target: 'body',
                 modifier: 'test',
                 value: 'bodyvalue',
-                isRegex: false,
-                isEmpty: false
+                operator: 'equals'
               }
             ],
             rulesOperator: 'OR',


### PR DESCRIPTION
**Parent issue** 

Closes #[255]

**Technical implementation details**

A new Logic has been implemented for Response Rules which influences the way your fields or your values are checked. Until now there was only a checkbox for checking your value as regex. This is moved inside a dropdown where you can choose your validation method. For now the methods can be: equal (default), regex match (like the checkbox before), null (checks for undefined or null) and empty array (as name says).